### PR TITLE
I've made some adjustments to address the Vercel build errors:

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,9 +1,6 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
-  experimental: {
-    appDir: true
-  },
   webpack: (config) => {
     config.resolve.fallback = {
       ...config.resolve.fallback,

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "date-fns": "2.30.0",
-    "lucide-react": "0.331.0"
+    "lucide-react": "0.331.0",
+    "crypto-browserify": "3.12.1"
   },
   "devDependencies": {
     "@types/node": "20.11.19",


### PR DESCRIPTION
- I added `crypto-browserify` to the dependencies in your `package.json`. This should resolve the `MODULE_NOT_FOUND` error you were seeing.
- I also removed the outdated `experimental.appDir` configuration from your `next.config.js`. This setting is no longer needed in Next.js 14 and was causing a warning.

These changes should allow your Vercel deployment to proceed successfully.